### PR TITLE
fix: remove junk locales files

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1,2 +1,0 @@
-en:
-  title: "My Title"

--- a/locales/pt.yml
+++ b/locales/pt.yml
@@ -1,2 +1,0 @@
-pt:
-  title: "Meu Título"


### PR DESCRIPTION
The page titles already in each front matter, don't need that `locales/` folder.

[See another way to declare vars using i18n](https://github.com/NeowayLabs/docs-api/blame/main/source/localizable/index.pt.html.md#L2):

```md
---
title: Neoway API
...
---
```
